### PR TITLE
update node-forge to version 1.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "jks-js",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jks-js",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
-        "node-forge": "^1.3.1",
+        "node-forge": "^1.3.2",
         "node-int64": "^0.4.0",
         "node-rsa": "^1.1.1"
       },
@@ -1641,9 +1641,9 @@
       "dev": true
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.2",
+      "resolved": "https://int.repositories.cloud.sap/artifactory/api/npm/build-milestones-npm/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
       "engines": {
         "node": ">= 6.13.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jks-js",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "jks-js is a converter of Java Key Store (JKS) to PEM certificates in order to securely connect to Java based servers using node js.",
   "main": "lib/index.js",
   "scripts": {
@@ -18,7 +18,7 @@
   "author": "Volodymyr Liench <lenchvov@gmail.com> (https://github.com/lenchv)",
   "license": "MIT",
   "dependencies": {
-    "node-forge": "^1.3.1",
+    "node-forge": "^1.3.2",
     "node-int64": "^0.4.0",
     "node-rsa": "^1.1.1"
   },


### PR DESCRIPTION
node-forge version 1.3.1 has a vulnerability of 8.6 (see [CVE-2025-12816](https://www.mend.io/vulnerability-database/CVE-2025-12816))
Updating to node-forge 1.3.2 will fix the issue. 

 "node-forge": "^1.3.1" in package.json is not working, because package-lock fixes the version to 1.3.1