### PR TITLE
update node-forge to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "jks-js",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jks-js",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
-        "node-forge": "^1.3.2",
+        "node-forge": "^1.4.0",
         "node-int64": "^0.4.0",
         "node-rsa": "^1.1.1"
       },
@@ -1641,9 +1641,9 @@
       "dev": true
     },
     "node_modules/node-forge": {
-      "version": "1.3.2",
-      "resolved": "https://int.repositories.cloud.sap/artifactory/api/npm/build-milestones-npm/node-forge/-/node-forge-1.3.2.tgz",
-      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
+      "version": "1.4.0",
+      "resolved": "https://int.repositories.cloud.sap/artifactory/api/npm/build-milestones-npm/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "engines": {
         "node": ">= 6.13.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jks-js",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "jks-js is a converter of Java Key Store (JKS) to PEM certificates in order to securely connect to Java based servers using node js.",
   "main": "lib/index.js",
   "scripts": {
@@ -18,7 +18,7 @@
   "author": "Volodymyr Liench <lenchvov@gmail.com> (https://github.com/lenchv)",
   "license": "MIT",
   "dependencies": {
-    "node-forge": "^1.3.2",
+    "node-forge": "^1.4.0",
     "node-int64": "^0.4.0",
     "node-rsa": "^1.1.1"
   },


### PR DESCRIPTION
update node-forge to 1.4.0 to mitigate HIGH vulnerabilities:
CVE-2026-33895 , CVE-2026-33896,  CVE-2026-33891,  CVE-2026-33894
