### PR TITLE
fix type of KeyEntry.chain

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -22,7 +22,7 @@ export type KeyEntry = {
   certType: 'X.509';
   alias: string;
   date: Date;
-  chain: Buffer[];
+  chain: Certificate[];
   protectedPrivateKey: Buffer;
 }
 


### PR DESCRIPTION
I noticed this from type checks failing after an upgrade.  From my understanding, this property is an array of KeyEntry objects, with the underlying buffers readable through the `.value` property:

https://github.com/lenchv/jks-js/blob/03c2cf3f44924138585416caa11bd4cc4ba10683/lib/keystore/JavaKeyStoreParser.js#L88-L95